### PR TITLE
Add: import PNG feature to reconstruct editable pixel grid (#18)

### DIFF
--- a/index.css
+++ b/index.css
@@ -176,3 +176,65 @@ header {
 .color-picker-label:hover {
   background-color: #2e2e2e;
 }
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  padding: 12px 16px;
+  min-width: 220px;
+  max-width: 300px;
+
+  font-size: 14px;
+  font-weight: 500;
+
+  border-radius: 8px;
+  color: #fff;
+
+  background: #1f2937;
+
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25);
+
+  z-index: 9999;
+
+  animation: toast-slide-in 0.3s ease, toast-fade-out 0.3s ease 2.7s forwards;
+}
+
+.toast.success {
+  background: #16a34a;
+}
+
+.toast.error {
+  background: #dc2626;
+}
+
+.toast.info {
+  background: #2563eb;
+}
+
+.toast i {
+  font-size: 16px;
+}
+
+@keyframes toast-slide-in {
+  from {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes toast-fade-out {
+  to {
+    opacity: 0;
+    transform: translateX(120%);
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,83 +1,166 @@
-const { useState } = React;
+const { useState, useRef } = React;
 
 const TOTAL_CELLS = 14;
 const MAX_HISTORY = 15;
 const DEFAULT_COLOR = '#2a2a2a';
 
-const App = () => {
-    const [cells, setCells] = useState(Array(TOTAL_CELLS * TOTAL_CELLS).fill(DEFAULT_COLOR));
-    const [history, setHistory] = useState([]);
-    const [future, setFuture] = useState([]);
-    const [selectedColor, setSelectedColor] = useState('#e63946');
-    const [isEraser, setIsEraser] = useState(false);
+const rgbToHex = (r, g, b) =>
+  '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
 
-    const paintCell = (index) => {
-        const newCells = [...cells];
-        newCells[index] = isEraser ? DEFAULT_COLOR : selectedColor;
+const App = () => {
+  const [cells, setCells] = useState(Array(TOTAL_CELLS * TOTAL_CELLS).fill(DEFAULT_COLOR));
+  const [history, setHistory] = useState([]);
+  const [future, setFuture] = useState([]);
+  const [selectedColor, setSelectedColor] = useState('#e63946');
+  const [isEraser, setIsEraser] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  const fileInputRef = useRef(null);
+
+  const showToast = (msg, type = 'error') => {
+    setToast({ msg, type });
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const triggerImport = () => fileInputRef.current?.click();
+
+  const paintCell = (index) => {
+    const newCells = [...cells];
+    newCells[index] = isEraser ? DEFAULT_COLOR : selectedColor;
+
+    setHistory(prev => [...prev.slice(-MAX_HISTORY + 1), cells]);
+    setFuture([]);
+    setCells(newCells);
+  };
+
+  const undo = () => {
+    if (!history.length) return;
+    const prev = history.at(-1);
+
+    setFuture(f => [cells, ...f.slice(0, MAX_HISTORY - 1)]);
+    setHistory(h => h.slice(0, -1));
+    setCells(prev);
+  };
+
+  const redo = () => {
+    if (!future.length) return;
+    const next = future[0];
+
+    setHistory(h => [...h.slice(-MAX_HISTORY + 1), cells]);
+    setFuture(f => f.slice(1));
+    setCells(next);
+  };
+
+  const clearAll = () => {
+    setHistory(prev => [...prev.slice(-MAX_HISTORY + 1), cells]);
+    setFuture([]);
+    setCells(Array(TOTAL_CELLS * TOTAL_CELLS).fill(DEFAULT_COLOR));
+  };
+
+  const downloadImage = async () => {
+    const grid = document.getElementById("pixel-grid");
+
+    grid.classList.add("no-border", "no-gap");
+
+    const canvas = await html2canvas(grid, {
+      backgroundColor: null,
+      scale: 8
+    });
+
+    grid.classList.remove("no-border", "no-gap");
+
+    const link = document.createElement("a");
+    link.download = "gridcraft.png";
+    link.href = canvas.toDataURL("image/png");
+    link.click();
+  };
+
+  const importImage = (e) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      showToast('Invalid image file');
+      return;
+    }
+
+    const reader = new FileReader();
+
+    reader.onload = (ev) => {
+      const img = new Image();
+
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = TOTAL_CELLS;
+        canvas.height = TOTAL_CELLS;
+
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, TOTAL_CELLS, TOTAL_CELLS);
+
+        const pixels = ctx.getImageData(0, 0, TOTAL_CELLS, TOTAL_CELLS).data;
+
+        const newCells = [];
+        const uniqueColors = new Set();
+
+        for (let i = 0; i < TOTAL_CELLS * TOTAL_CELLS; i++) {
+          const r = pixels[i * 4];
+          const g = pixels[i * 4 + 1];
+          const b = pixels[i * 4 + 2];
+          const a = pixels[i * 4 + 3];
+
+          uniqueColors.add(`${r}-${g}-${b}`);
+
+          newCells.push(a < 30 ? DEFAULT_COLOR : rgbToHex(r, g, b));
+        }
+
+        if (uniqueColors.size > 80) {
+          if (!window.confirm("Image too detailed. Continue?")) return;
+        }
+
         setHistory(prev => [...prev.slice(-MAX_HISTORY + 1), cells]);
         setFuture([]);
         setCells(newCells);
+
+        showToast('Image imported!', 'success');
+      };
+
+      img.src = ev.target.result;
     };
 
-    const undo = () => {
-        if (history.length === 0) return;
-        const prev = history[history.length - 1];
-        setFuture(f => [cells, ...f.slice(0, MAX_HISTORY - 1)]);
-        setHistory(h => h.slice(0, -1));
-        setCells(prev);
-    };
+    reader.readAsDataURL(file);
+  };
 
-    const redo = () => {
-        if (future.length === 0) return;
-        const next = future[0];
-        setHistory(h => [...h.slice(-MAX_HISTORY + 1), cells]);
-        setFuture(f => f.slice(1));
-        setCells(next);
-    };
+  return (
+    <>
+      <Header />
 
-    const clearAll = () => {
-        setHistory(prev => [...prev.slice(-MAX_HISTORY + 1), cells]);
-        setFuture([]);
-        setCells(Array(TOTAL_CELLS * TOTAL_CELLS).fill(DEFAULT_COLOR));
-    };
+      <Menu downloadImage={downloadImage} onImport={triggerImport} />
+      <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={importImage}
+      />
 
-    const downloadImage = async () => {
-        const grid = document.getElementById("pixel-grid");
+      {toast && <div className={`toast ${toast.type}`}>{toast.msg}</div>}
 
-        // Remove borders + gap
-        grid.classList.add("no-border");
-        grid.classList.add("no-gap");
+      <Grid cells={cells} paintCell={paintCell} />
 
-        const canvas = await html2canvas(grid, {
-            backgroundColor: null,
-            scale: 8
-        });
+      <Tools
+        undo={undo}
+        redo={redo}
+        canUndo={history.length > 0}
+        canRedo={future.length > 0}
+        selectedColor={selectedColor}
+        setSelectedColor={setSelectedColor}
+        isEraser={isEraser}
+        setIsEraser={setIsEraser}
+        clearAll={clearAll}
+      />
 
-        grid.classList.remove("no-border");
-        grid.classList.remove("no-gap");
-
-        const link = document.createElement("a");
-        link.download = "gridcraft.png";
-        link.href = canvas.toDataURL("image/png");
-        link.click();
-    };
-    return (
-        <>
-            <Header />
-            <Menu downloadImage={downloadImage} />
-            <Grid cells={cells} paintCell={paintCell} />
-            <Tools
-                undo={undo}
-                redo={redo}
-                canUndo={history.length > 0}
-                canRedo={future.length > 0}
-                selectedColor={selectedColor}
-                setSelectedColor={setSelectedColor}
-                isEraser={isEraser}
-                setIsEraser={setIsEraser}
-                clearAll={clearAll}
-            />
-            <Footer />
-        </>
-    );
-}
+      <Footer />
+    </>
+  );
+};

--- a/src/Menu.jsx
+++ b/src/Menu.jsx
@@ -1,13 +1,23 @@
-const Menu = ({ downloadImage }) => {
+const Menu = ({ downloadImage, onImport }) => {
+    const openLink = (url) => window.open(url, "_blank");
+
     return (
         <div className="menu-cont">
-            <button className="menu-btn" onClick={downloadImage}><i className="fa-regular fa-file-image"></i></button>
-            <button className="menu-btn" onClick={() => window.location.href = "https://github.com/Rohan-Shridhar/gridcraft"}>
+            <button className="menu-btn" onClick={downloadImage} title="Export">
+                <i className="fa-regular fa-file-image"></i>
+            </button>
+
+            <button className="menu-btn" onClick={onImport} title="Import">
+                <i className="fa-solid fa-upload"></i>
+            </button>
+
+            <button className="menu-btn" onClick={() => openLink("https://github.com/Rohan-Shridhar/gridcraft")}>
                 <i className="fab fa-github"></i>
             </button>
-            <button className="menu-btn" onClick={() => window.location.href = "https://github.com/Rohan-Shridhar/gridcraft/forks"}>
+
+            <button className="menu-btn" onClick={() => openLink("https://github.com/Rohan-Shridhar/gridcraft/forks")}>
                 <i className="fa-solid fa-code-fork"></i>
             </button>
         </div>
     );
-}
+};


### PR DESCRIPTION
## ✨ Feature: Import Pixel Art (14×14 Grid)

Added support to import images and convert them into an editable 14×14 pixel grid.

### Key Features

* Upload PNG/image files
* Auto-resize image to 14×14 grid
* Extract pixel colors and map to grid cells
* Handle transparency with default color
* Detect high-detail images and warn user
* Imported grid is fully editable (paint, erase, undo/redo)
* Added toast messages for feedback

###  Result

Users can now import and re-edit pixel art or convert any image into pixel format.
### Screenshots: 
<img width="373" height="340" alt="image" src="https://github.com/user-attachments/assets/9d61dfa4-6c58-4886-90eb-773c033c9b7b" />

<img width="706" height="1025" alt="{1CEC1031-AC04-4A63-B4E9-6CC1FA189F36}" src="https://github.com/user-attachments/assets/46b76d14-7ec8-4f3b-9095-5c56c129a7e9" />


Closes issue: *Import Pixel Art for Editing*