### PR TITLE
feat: add beforeunload warning to prevent accidental progress loss

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,19 @@ const App = () => {
 
   const fileInputRef = useRef(null);
 
+  React.useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = ''; 
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   const showToast = (msg, type = 'error') => {
     setToast({ msg, type });
     setTimeout(() => setToast(null), 3000);


### PR DESCRIPTION
Fixes #28

Added a `beforeunload` event listener that displays a browser warning when users attempt to refresh or close the page, preventing accidental loss of their pixel art progress.

## Changes:
- Added `useEffect` hook in `App.jsx` to listen for page unload events
- Browser now shows native confirmation dialog before refresh/close

## Testing:
- Tested by drawing on the grid and attempting to refresh (F5/Ctrl+R)
- Warning popup appears as expected
<img width="769" height="458" alt="Screenshot 2026-04-10 140553" src="https://github.com/user-attachments/assets/80fc66b9-5fc0-4396-8070-623b943ac94e" />
