### PR TITLE
fix: update Rohan Shridhar footer link to current portfolio

### DIFF
--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -1,7 +1,7 @@
 const Footer = () => {
     return (
         <div className="footer-cont">
-            <p>Built with <i class="fa-brands fa-react"></i> by <a href="https://rohan-shridhar.github.io/portfolio">Rohan Shridhar</a></p>
+            <p>Built with <i className="fa-brands fa-react"></i> by <a href="https://rohan-shridhar.github.io/rohan-shridhar/">Rohan Shridhar</a></p>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
Fix the footer byline in `src/Footer.jsx` so "Rohan Shridhar" links to the current portfolio URL `https://rohan-shridhar.github.io/rohan-shridhar/` (the issue's target), and change the companion `class="fa-brands fa-react"` to `className` so React stops complaining in dev mode.

## Why this matters
Issue #42 asks for the link redirect. The old `https://rohan-shridhar.github.io/portfolio` target currently 301-redirects — useful but not the canonical site. Swapping to the explicit target avoids the extra round-trip and matches what the user sees when they follow the redirect anyway.

## Changes
- `src/Footer.jsx`:
  - `href="https://rohan-shridhar.github.io/portfolio"` → `href="https://rohan-shridhar.github.io/rohan-shridhar/"`
  - `class="fa-brands fa-react"` → `className="fa-brands fa-react"` so the React dev warning goes away (the outer `<div>` already uses `className`, so this is a consistency fix in the same line).

## Testing
```
$ curl -sI https://rohan-shridhar.github.io/rohan-shridhar/
HTTP/2 200
```

The new URL resolves to 200. The old `portfolio` path was 301'ing to the same target content.

Fixes #42

This contribution was developed with AI assistance (Claude Code).
