### PR TITLE
docs(contributing): add Pull Request description template (#34)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,54 @@ If it fits the project, you’re welcome to implement it!
 
 ---
 
+## 📝 Pull Request Template
+
+Use this template for the description of every Pull Request. Copy it into the PR body and fill out each section. Sections that don't apply can be marked `N/A` rather than removed -- it makes review faster when the structure is consistent across PRs.
+
+```markdown
+## Summary
+
+<!-- One or two sentences describing what this PR changes and why. -->
+
+## Related Issue
+
+<!-- Link the issue this PR addresses, e.g. "Closes #123" or "Relates to #45". -->
+
+## Type of Change
+
+<!-- Check whichever applies. Multiple is fine. -->
+
+- [ ] 🐞 Bug fix
+- [ ] ✨ New feature / grid utility
+- [ ] 🎨 UI improvement
+- [ ] 🚀 Performance optimization
+- [ ] 📚 Documentation update
+- [ ] 🧹 Refactor (no behavior change)
+- [ ] 🧪 Tests only
+
+## Screenshots / Recording
+
+<!-- For any UI change, include a before/after screenshot or short clip.
+     For non-UI changes, write "N/A". -->
+
+## How to Test
+
+<!-- Steps a reviewer can follow to verify the change locally:
+     1. Open `index.html` in a browser
+     2. ...
+     3. Expected: ... -->
+
+## Checklist
+
+- [ ] My code runs without errors
+- [ ] I tested the change in a browser
+- [ ] PR is focused on a single feature or fix
+- [ ] No new dependencies added (or, if added, justified above)
+- [ ] Updated documentation if behavior changed
+```
+
+---
+
 ## 🙌 Final Note
 
 Keep it clean. Keep it useful.  


### PR DESCRIPTION
## Summary

Adds a Pull Request description template section to `CONTRIBUTING.md` so contributors have a consistent structure to follow when filling out the PR body.

Closes #34

## Why this matters

Issue #34 sits next to issues #35 (issue template), #36 (clearer CONTRIBUTING sections), and #46 -- the maintainer is gradually building out the contribution scaffolding. A PR template inside CONTRIBUTING.md is the smallest, most focused piece of that work and matches the issue's `no code` label.

## Changes

- `CONTRIBUTING.md`: new `## 📝 Pull Request Template` section between the existing `Before Submitting PR` checklist and the `Final Note` block, so contributors hit it right after they've finished testing and are about to write the PR body.
- The template covers Summary, Related Issue, Type of Change checklist, Screenshots / Recording, How to Test, and a final Checklist -- all wrapped in a code fence so contributors can copy-paste the raw markdown directly into the PR body.
- HTML comments explain each section so new contributors know what to put there without removing the comments first.

## Testing

- `CONTRIBUTING.md` renders correctly on GitHub (markdown headings, code fence, checkbox lists)
- `git diff --stat`: `1 file changed, 48 insertions(+)` -- additive, no existing content removed

## Notes for the maintainer

If you'd prefer the PR template to live as a separate `.github/PULL_REQUEST_TEMPLATE.md` (which GitHub auto-fills into the PR body) instead of inline in CONTRIBUTING.md, happy to move it -- the issue specifically asked for CONTRIBUTING.md so I followed that. The two approaches aren't mutually exclusive and both can co-exist.

This contribution was developed with AI assistance (Claude Code).
