### PR TITLE
fix(grid): disable re-selecting the active grid size

### DIFF
--- a/index.css
+++ b/index.css
@@ -125,13 +125,16 @@ header {
     background-color 0.2s ease,
     color 0.2s ease;
 }
-.grid-size-btn:hover {
+.grid-size-btn:hover:not(:disabled) {
   background-color: var(--text-color);
   color: var(--bg-color);
 }
 .grid-size-btn--active {
   background-color: var(--text-color);
   color: var(--bg-color);
+}
+.grid-size-btn:disabled {
+  cursor: not-allowed;
 }
 
 /* ── Grid ───────────────────────────────────────── */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,8 @@ const App = () => {
   };
 
   const changeGridSize = (newSize) => {
+    if (newSize === gridSize) return;
+
     if (
       !window.confirm(
         "Changing grid size will clear your current drawing. Continue?"
@@ -270,6 +272,9 @@ const App = () => {
             className={`grid-size-btn${gridSize === size ? " grid-size-btn--active" : ""
               }`}
             onClick={() => changeGridSize(size)}
+            disabled={gridSize === size}
+            aria-pressed={gridSize === size}
+            title={gridSize === size ? `Already on ${size}×${size}` : `Switch to ${size}×${size}`}
           >
             {size}×{size}
           </button>


### PR DESCRIPTION
Resolves #32.

Clicking the currently-selected grid-size button used to fire the \"this will clear your drawing\" confirm prompt again and, on accept, wipe the canvas.

## Fix

Defense in depth, both behavioural and visual:

- **\`changeGridSize\`** bails out early when \`newSize === gridSize\`, so duplicate calls become a no-op even if the click reaches the handler.
- **The button** carries \`disabled={gridSize === size}\` and \`aria-pressed={gridSize === size}\`, so the click is short-circuited and the state is announced to assistive tech.
- **CSS** uses \`cursor: not-allowed\` on the disabled button and gates the hover effect on \`:not(:disabled)\` so the active button stops feeling clickable.

The active highlight (\`grid-size-btn--active\`) is unchanged.