### PR TITLE
Add keyboard shortcuts for undo and redo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,25 @@ const App = () => {
 
   const fileInputRef = useRef(null);
 
+  const handleKeyPress = useCallback((event) => {
+    if (event.key === "z" && event.ctrlKey && history.length) {
+      undo()
+      showToast("Undo", "success")
+    }
+    else if (event.key === "y" && event.ctrlKey && future.length){
+      redo()
+      showToast("Redo", "success")
+    }
+  }, [history, future]);
+
+  React.useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
   React.useEffect(() => {
     const handleBeforeUnload = (e) => {
       e.preventDefault();

--- a/src/Tools.jsx
+++ b/src/Tools.jsx
@@ -22,7 +22,7 @@ const Tools = ({
                     showToast("Undo", "success");
                 }}
                 disabled={!canUndo}
-                title="Undo"
+                title="Undo (Ctrl+Z)"
             >
                 <i className="fa-solid fa-rotate-left"></i>
             </button>
@@ -35,7 +35,7 @@ const Tools = ({
                     showToast("Redo", "success");
                 }}
                 disabled={!canRedo}
-                title="Redo"
+                title="Redo (Ctrl+Y)"
             >
                 <i className="fa-solid fa-rotate-right"></i>
             </button>


### PR DESCRIPTION
## Summary

This commit makes Ctrl+z undo and Ctrl+y redo. It also changes titles on those tools to display the shortcut for them.

## Related Issue

Closes #44

## Type of Change

<!-- Check whichever applies. Multiple is fine. -->

- [ ] 🐞 Bug fix
- [✔️] ✨ New feature / grid utility
- [ ] 🎨 UI improvement
- [ ] 🚀 Performance optimization
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor (no behavior change)
- [ ] 🧪 Tests only

## Screenshots / Recording

"N/A"

## How to Test

     1. Open the project directory
     2. Run npx serve
     3. Open the url listed in your browser and make changes to the grid
     4. Press Ctrl + z to undo changes and Ctrl + y to redo changes

## Checklist

- [✔️] My code runs without errors
- [✔️] I tested the change in a browser
- [✔️] PR is focused on a single feature or fix
- [✔️] No new dependencies added (or, if added, justified above)
- [ ] Updated documentation if behavior changed