### PR TITLE
fix: disable editing tools when preview mode is enabled

### DIFF
--- a/index.css
+++ b/index.css
@@ -230,6 +230,11 @@ header {
 .color-picker-label:hover {
   background-color: #2e2e2e;
 }
+.color-picker-label--disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 
 .toast {
   position: fixed;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ const App = () => {
   const fileInputRef = useRef(null);
 
   const handleKeyPress = useCallback((event) => {
+    if (!showGrid) return;
     if (event.key === "z" && event.ctrlKey && history.length) {
       undo()
       showToast("Undo", "success")
@@ -39,7 +40,7 @@ const App = () => {
       redo()
       showToast("Redo", "success")
     }
-  }, [history, future]);
+  }, [history, future, showGrid]);
 
   React.useEffect(() => {
     document.addEventListener('keydown', handleKeyPress);
@@ -320,6 +321,7 @@ const App = () => {
         setIsFill={setIsFill}
         clearAll={clearAll}
         showToast={showToast}
+        isPreview={!showGrid}
       />
 
       <Footer />

--- a/src/Tools.jsx
+++ b/src/Tools.jsx
@@ -10,39 +10,41 @@ const Tools = ({
     isFill,
     setIsFill,
     clearAll,
-    showToast
+    showToast,
+    isPreview = false
 }) => {
+    const previewTitle = isPreview ? "Disabled in preview mode" : null;
     return (
         <div className="tools-cont">
             {/* Undo */}
             <button
-                className={`tool-btn${!canUndo ? ' tool-btn--disabled' : ''}`}
+                className={`tool-btn${!canUndo || isPreview ? ' tool-btn--disabled' : ''}`}
                 onClick={() => {
                     undo();
                     showToast("Undo", "success");
                 }}
-                disabled={!canUndo}
-                title="Undo (Ctrl+Z)"
+                disabled={!canUndo || isPreview}
+                title={previewTitle ?? "Undo (Ctrl+Z)"}
             >
                 <i className="fa-solid fa-rotate-left"></i>
             </button>
 
             {/* Redo */}
             <button
-                className={`tool-btn${!canRedo ? ' tool-btn--disabled' : ''}`}
+                className={`tool-btn${!canRedo || isPreview ? ' tool-btn--disabled' : ''}`}
                 onClick={() => {
                     redo();
                     showToast("Redo", "success");
                 }}
-                disabled={!canRedo}
-                title="Redo (Ctrl+Y)"
+                disabled={!canRedo || isPreview}
+                title={previewTitle ?? "Redo (Ctrl+Y)"}
             >
                 <i className="fa-solid fa-rotate-right"></i>
             </button>
 
             {/* Eraser */}
             <button
-                className={`tool-btn${isEraser ? ' tool-btn--active' : ''}`}
+                className={`tool-btn${isEraser ? ' tool-btn--active' : ''}${isPreview ? ' tool-btn--disabled' : ''}`}
                 onClick={() => {
                     const next = !isEraser;
                     setIsEraser(next);
@@ -51,14 +53,15 @@ const Tools = ({
                         showToast("🧽 Eraser selected", "success");
                     }
                 }}
-                title="Eraser"
+                disabled={isPreview}
+                title={previewTitle ?? "Eraser"}
             >
                 <i className="fa-solid fa-eraser"></i>
             </button>
 
             {/* Fill */}
             <button
-                className={`tool-btn${isFill ? ' tool-btn--active' : ''}`}
+                className={`tool-btn${isFill ? ' tool-btn--active' : ''}${isPreview ? ' tool-btn--disabled' : ''}`}
                 onClick={() => {
                     const next = !isFill;
                     setIsFill(next);
@@ -67,19 +70,25 @@ const Tools = ({
                         showToast("🪣 Fill tool selected", "success");
                     }
                 }}
-                title="Fill"
+                disabled={isPreview}
+                title={previewTitle ?? "Fill"}
             >
                 <i className="fa-solid fa-fill-drip"></i>
             </button>
 
             {/* Color Picker */}
-            <label className="color-picker-label" title="Pick a color">
+            <label
+                className={`color-picker-label${isPreview ? ' color-picker-label--disabled' : ''}`}
+                title={previewTitle ?? "Pick a color"}
+            >
                 <i className="fa-solid fa-palette"></i>
                 <input
                     type="color"
                     className="color-input"
                     value={selectedColor}
+                    disabled={isPreview}
                     onChange={e => {
+                        if (isPreview) return;
                         setSelectedColor(e.target.value);
                         setIsEraser(false);
                         setIsFill(false);
@@ -90,13 +99,14 @@ const Tools = ({
 
             {/* Clear All */}
             <button
-                className="tool-btn"
+                className={`tool-btn${isPreview ? ' tool-btn--disabled' : ''}`}
                 onClick={() => {
                     if (!window.confirm("Clear the entire canvas?")) return;
                     clearAll();
                     showToast("Canvas cleared", "success");
                 }}
-                title="Clear All"
+                disabled={isPreview}
+                title={previewTitle ?? "Clear All"}
             >
                 <i className="fa-solid fa-trash-can"></i>
             </button>


### PR DESCRIPTION
## Summary

Closes #31.

The maintainer's follow-up comment on #31 noted that after the initial fix in cef4c54, "Options to delete, undo/redo and fill color is still working when preview is enabled". The grid click path was already gated, but Tools.jsx (undo, redo, eraser, fill, color picker, clear-all) and the Ctrl+Z / Ctrl+Y shortcuts in App.jsx were not.

This passes `isPreview={!showGrid}` to Tools and disables every editing button when preview is on. Same flag also gates the keyboard shortcuts so users cannot edit via Ctrl+Z / Ctrl+Y while previewing.

## Files

- `src/Tools.jsx` - new `isPreview` prop. Each tool button has its `disabled` and `tool-btn--disabled` class extended with `|| isPreview`. Color picker label gets a `color-picker-label--disabled` modifier and the input gets `disabled={isPreview}`. Tooltips switch to "Disabled in preview mode" when in preview.
- `src/App.jsx` - pass `isPreview={!showGrid}` to `<Tools>`. Add `if (!showGrid) return;` to `handleKeyPress` so Ctrl+Z / Ctrl+Y do not undo/redo while previewing. Add `showGrid` to the useCallback dep array.
- `index.css` - new `.color-picker-label--disabled` rule mirroring the existing `.tool-btn--disabled` (opacity + not-allowed cursor).

## Test plan

- [x] Toggle preview button on, click undo/redo/eraser/fill/clear -> all visually disabled, no-op.
- [x] Toggle preview on, press Ctrl+Z / Ctrl+Y -> no action, no toast.
- [x] Toggle preview on, click color picker -> input disabled.
- [x] Toggle preview off -> all tools work as before.
- [x] No regression to grid click path (was already gated by `if (!showGrid) return`).

No new dependencies, no new tests (project has no test suite yet).