### PR TITLE
Display use desktop toast when on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,6 +56,19 @@ const App = () => {
       e.returnValue = "";
     };
 
+    const isMobile = () => {
+      if (navigator.userAgentData) {
+        return navigator.userAgentData.mobile;
+      }
+
+      // Fallback for browsers that don't support userAgentData.mobile
+      return /Mobi|Android/i.test(navigator.userAgent);
+      };
+
+    if (isMobile()) {
+      showToast("Switch to desktop");
+    }
+
     const handleResize = () => {
       setIsSmallScreen(window.innerWidth < 768 || window.innerHeight < 768);
     };


### PR DESCRIPTION
## Summary

This PR makes a `Switch to Desktop` toast appear when a user is on a mobile device such as a phone or tablet. This pr uses the top method from this website to do so: https://codeshack.io/detect-mobile-devices-javascript/

## Related Issue

Closes #46

## Type of Change

<!-- Check whichever applies. Multiple is fine. -->

- [ ] 🐞 Bug fix
- [ ] ✨ New feature / grid utility
- [x] 🎨 UI improvement
- [ ] 🚀 Performance optimization
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor (no behavior change)
- [ ] 🧪 Tests only

## Screenshots / Recording

<!-- For any UI change, include a before/after screenshot or short clip.
     For non-UI changes, write "N/A". -->
<img width="200" height="400" alt="Screenshot_20260429_185021_DuckDuckGo" src="https://github.com/user-attachments/assets/204380ae-712f-4398-ba00-8724c70a1796" />

## How to Test

     1. enter the project directory in a terminal
     2. run `npx serve`
     3. visit the link on the right of "Network" on a mobile device
     Expected: A toast saying "Switch to Desktop" should appear once the page loads.

## Checklist

- [x] My code runs without errors
- [x] I tested the change in a browser
- [x] PR is focused on a single feature or fix
- [x] No new dependencies added (or, if added, justified above)
- [ ] Updated documentation if behavior changed