### PR TITLE
feat: add keyboard shortcuts for toolbar tools (eraser, fill, paint, clear)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,13 +32,44 @@ const App = () => {
 
   const handleKeyPress = useCallback((event) => {
     if (!showGrid) return;
-    if (event.key === "z" && event.ctrlKey && history.length) {
+    const eventKey=event.key.toLowerCase();
+    
+    if (eventKey === "z" && event.ctrlKey && history.length) {
       undo()
       showToast("Undo", "success")
     }
-    else if (event.key === "y" && event.ctrlKey && future.length){
+    else if (eventKey === "y" && event.ctrlKey && future.length){
       redo()
       showToast("Redo", "success")
+    }
+    else if(eventKey==="e"){
+      setIsEraser((prev)=>{
+        const newValue=!prev;
+        if(newValue){
+          showToast("Eraser tool selected","success");
+        }
+        return newValue;
+      })
+      setIsFill(false);
+    }
+    else if(eventKey==="b"){
+      setIsFill((prev)=>{
+        const newValue=!prev;
+        if(newValue){
+          showToast("Fill tool selected","success");
+        }
+        return newValue;
+      })
+      setIsEraser(false);
+    }
+    else if(eventKey==="a"){
+      setIsEraser(false);
+      setIsFill(false);
+      showToast("Paint brush tool selected","success");
+    }else if(eventKey==="c"){
+      if (!window.confirm("Clear the entire canvas?")) return;
+      clearAll();
+      showToast("Canvas cleared", "success");
     }
   }, [history, future, showGrid]);
 

--- a/src/Tools.jsx
+++ b/src/Tools.jsx
@@ -54,7 +54,7 @@ const Tools = ({
                     }
                 }}
                 disabled={isPreview}
-                title={previewTitle ?? "Eraser"}
+                title={previewTitle ?? "Eraser (E)"}
             >
                 <i className="fa-solid fa-eraser"></i>
             </button>
@@ -71,7 +71,7 @@ const Tools = ({
                     }
                 }}
                 disabled={isPreview}
-                title={previewTitle ?? "Fill"}
+                title={previewTitle ?? "Fill (B)"}
             >
                 <i className="fa-solid fa-fill-drip"></i>
             </button>
@@ -79,7 +79,7 @@ const Tools = ({
             {/* Color Picker */}
             <label
                 className={`color-picker-label${isPreview ? ' color-picker-label--disabled' : ''}`}
-                title={previewTitle ?? "Pick a color"}
+                title={previewTitle ?? "Pick a color (A)"}
             >
                 <i className="fa-solid fa-palette"></i>
                 <input
@@ -106,7 +106,7 @@ const Tools = ({
                     showToast("Canvas cleared", "success");
                 }}
                 disabled={isPreview}
-                title={previewTitle ?? "Clear All"}
+                title={previewTitle ?? "Clear All (C)"}
             >
                 <i className="fa-solid fa-trash-can"></i>
             </button>


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for toolbar tools to improve accessibility and workflow speed.

## Related Issue

Closes #53

## Type of Change

- [ ] 🐞 Bug fix
- [x] ✨ New feature / grid utility
- [ ] 🎨 UI improvement
- [ ] 🚀 Performance optimization
- [ ] 📚 Documentation update
- [ ] 🧹 Refactor (no behavior change)
- [ ] 🧪 Tests only

## Screenshots / Recording

N/A

## How to Test

1. Open `index.html` in a browser
2. Verify the following keyboard shortcuts:
   - `E` → Select Eraser tool
   - `B` → Select Fill tool
   - `A` → Select Paint Brush tool
   - `C` → Clear the canvas

## Checklist

- [x] My code runs without errors
- [x] I tested the change in a browser
- [x] PR is focused on a single feature or fix
- [x] No new dependencies added (or, if added, justified above)
- [ ] Updated documentation if behavior changed