### PR TITLE
docs: add keyboard shortcuts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Built with React, GridCraft demonstrates how modern component-based architecture
 - **Clear Canvas** - Start fresh with a single click
 - **Real-time Updates** - See your changes instantly as you draw
 
+## Keyboard Shortcuts
+
+Shortcuts work while the drawing grid is visible:
+
+| Action | Shortcut |
+| --- | --- |
+| Undo | `Ctrl + Z` |
+| Redo | `Ctrl + Y` |
+| Eraser | `E` |
+| Bucket / Fill tool | `B` |
+| Color picker / Paint brush | `A` |
+| Clear canvas | `C` |
+
 
 ## Live Demo 🚀
 


### PR DESCRIPTION
Closes #60

## Summary
- Added a Keyboard Shortcuts section to README.md.
- Documented Undo, Redo, Eraser, Bucket / Fill, Color picker / Paint brush, and Clear canvas shortcuts.
- Matched the documented shortcuts to the current key handling in src/App.jsx and tool titles in src/Tools.jsx.

## Validation
git diff --check (passed; reported only the existing Windows line-ending conversion warning)

- g -n 'Ctrl \\+ Z|Ctrl \\+ Y|Eraser|Bucket / Fill tool|Color picker / Paint brush|Clear canvas' README.md

- g -n 'eventKey.*z|eventKey.*y|eventKey.*e|eventKey.*b|eventKey.*a|eventKey.*c' src\\App.jsx

- g -n 'Undo \\(Ctrl\\+Z\\)|Redo \\(Ctrl\\+Y\\)|Eraser \\(E\\)|Fill \\(B\\)|Pick a color \\(A\\)|Clear All \\(C\\)' src\\Tools.jsx

- package.json not found; no npm lint/test scripts available.