### PR TITLE
fix: remove emoji from tool toasts

### DIFF
--- a/src/Tools.jsx
+++ b/src/Tools.jsx
@@ -50,7 +50,7 @@ const Tools = ({
                     setIsEraser(next);
                     if (next) {
                         setIsFill(false);
-                        showToast("🧽 Eraser selected", "success");
+                        showToast("Eraser selected", "success");
                     }
                 }}
                 disabled={isPreview}
@@ -67,7 +67,7 @@ const Tools = ({
                     setIsFill(next);
                     if (next) {
                         setIsEraser(false);
-                        showToast("🪣 Fill tool selected", "success");
+                        showToast("Fill tool selected", "success");
                     }
                 }}
                 disabled={isPreview}
@@ -92,7 +92,7 @@ const Tools = ({
                         setSelectedColor(e.target.value);
                         setIsEraser(false);
                         setIsFill(false);
-                        showToast(`🎨 Color selected`, "success");
+                        showToast("Color selected", "success");
                     }}
                 />
             </label>


### PR DESCRIPTION
## Summary

Remove emoji prefixes from tool selection toast messages so eraser, fill, and color picker notifications use plain text.

## Related Issue

Closes #66

## Type of Change

- [x] UI improvement

## Screenshots / Recording

N/A - text-only toast copy change.

## How to Test

1. Open index.html in a browser.
2. Select the eraser, fill tool, and color picker.
3. Expected: each toast displays plain text without emoji.

## Checklist

- [x] My code runs without errors
- [x] I tested the change by checking the toast message source
- [x] PR is focused on a single feature or fix
- [x] No new dependencies added
- [x] Updated documentation if behavior changed: N/A