### PR TITLE
fix: disable grid size selection in preview

### DIFF
--- a/index.css
+++ b/index.css
@@ -160,6 +160,9 @@ header {
 .grid-size-btn:disabled {
   cursor: not-allowed;
 }
+.grid-size-btn--disabled {
+  opacity: 0.35;
+}
 
 /* ── Grid ───────────────────────────────────────── */
 .grid-cont {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -314,6 +314,13 @@ const App = () => {
     reader.readAsDataURL(file);
   };
 
+  const isPreview = !showGrid;
+  const getGridSizeTitle = (size) => {
+    if (isPreview) return "Disabled in preview mode";
+    if (gridSize === size) return `Already on ${size}×${size}`;
+    return `Switch to ${size}×${size}`;
+  };
+
   return (
     <>
       <Header isDarkTheme={isDarkTheme} toggleTheme={toggleTheme} />
@@ -344,11 +351,11 @@ const App = () => {
           <button
             key={size}
             className={`grid-size-btn${gridSize === size ? " grid-size-btn--active" : ""
-              }`}
+              }${isPreview ? " grid-size-btn--disabled" : ""}`}
             onClick={() => changeGridSize(size)}
-            disabled={gridSize === size}
+            disabled={isPreview || gridSize === size}
             aria-pressed={gridSize === size}
-            title={gridSize === size ? `Already on ${size}×${size}` : `Switch to ${size}×${size}`}
+            title={getGridSizeTitle(size)}
           >
             {size}×{size}
           </button>
@@ -375,7 +382,7 @@ const App = () => {
         setIsFill={setIsFill}
         clearAll={clearAll}
         showToast={showToast}
-        isPreview={!showGrid}
+        isPreview={isPreview}
       />
 
       <Footer />


### PR DESCRIPTION
## Summary

Disable grid size selection while preview mode is active, matching the existing disabled state for drawing tools. The preview toggle remains enabled so users can exit preview mode.

## Related Issue

Closes #67

## Type of Change

- [x] UI improvement

## Screenshots / Recording

N/A - control state behavior change.

## How to Test

1. Open index.html in a browser.
2. Click the eye button to enter preview mode.
3. Expected: grid size buttons are disabled and visually dimmed.
4. Expected: the eye button remains enabled so preview mode can be exited.

## Checklist

- [x] My code runs without errors
- [x] I tested the change in a browser with Playwright
- [x] PR is focused on a single feature or fix
- [x] No new dependencies added
- [x] Updated documentation if behavior changed: N/A