### PR TITLE
docs: fix inconsistent grid sizes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/rohan-shridhar/gridcraft)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/rohan-shridhar/gridcraft)
 
-A React-powered pixel art tool that lets you paint on a 15x15 grid with the full RGB color spectrum.
+A React-powered pixel art tool that lets you paint on a customizable grid (16×16, 32×32, 64×64, or 128×128) with the full RGB color spectrum.
 
 ## Why GridCraft? 🎯
 
@@ -10,7 +10,7 @@ Built with React, GridCraft demonstrates how modern component-based architecture
 
 ## Features ✨
 
-- **14x14 Drawing Grid** - A perfectly sized canvas for pixel art and simple designs
+- **Multiple Grid Sizes** - Draw on a 16×16, 32×32, 64×64, or 128×128 canvas depending on your project
 - **Full RGB Color Support** - Choose any color using an intuitive RGB color picker
 - **Export as PNG** - Download your creations to save and share
 - **Right-Click to Draw** - Intuitive drawing mechanism using right mouse button
@@ -68,7 +68,7 @@ gridcraft/
 - **In-Browser JSX Transpilation** - Babel Standalone converts JSX syntax to JavaScript at runtime
 - **Component Architecture** - Modular design with seven specialized components:
   - `App.jsx` - Root component managing core state and download logic
-  - `Grid.jsx` - Renders 14x14 grid and handles cell painting
+  - `Grid.jsx` - Renders the drawing grid (16×16 up to 128×128) and handles cell painting
   - `Tools.jsx` - Drawing tools (color picker, eraser, undo/redo, clear)
   - `Menu.jsx` - Download button and high-level controls
   - `Header.jsx` & `Footer.jsx` - Layout components


### PR DESCRIPTION
## What changed
Fixed inconsistent grid size references in README.md. The README mentioned a 15x15 grid in the intro and a 14x14 grid in two other places, while the app actually supports 16×16, 32×32, 64×64, and 128×128 (confirmed in `src/App.jsx`'s `GRID_SIZES` array).

closes #87 

## How I tested it
Verified the actual supported sizes directly in the source code (`GRID_SIZES = [16, 32, 64, 128]` in `App.jsx`) before updating the docs, and checked `Manual.md` — it already listed the correct sizes, so no changes